### PR TITLE
Fix allowed task names

### DIFF
--- a/run
+++ b/run
@@ -33,8 +33,9 @@ ACTION=(run::action-list)
 
 # Regex patterns for parsing the task file.
 COMMENT_PATTERN='^#{1,}[[:blank:]]?(.*)$'
-TASK_DEF_PATTERN_1='^[[:blank:]]*run::([a-zA-Z0-9_-]+)[[:blank:]]*\([[:blank:]]*\)'
-TASK_DEF_PATTERN_2='^[[:blank:]]*function[[:blank:]]*run::([a-zA-Z0-9_-]+)'
+TASK_NAME_PATTERN='[a-zA-Z]+[a-zA-Z0-9:_-]*'
+TASK_DEF_PATTERN_1='^[[:blank:]]*run::('"${TASK_NAME_PATTERN}"')[[:blank:]]*\([[:blank:]]*\)'
+TASK_DEF_PATTERN_2='^[[:blank:]]*function[[:blank:]]*run::('"${TASK_NAME_PATTERN}"')'
 
 # The --help procedure.
 run::action-help() {
@@ -44,9 +45,9 @@ run::action-help() {
 	echo
 	echo 'Options:'
 	echo '  -f, --file       Specify the task file (default: ./run.sh)'
-	echo '  -h, --help       Print this help'
 	echo '  -i, --info task  Show task description'
 	echo '  -l, --list       List all available tasks'
+	echo '  -h, --help       Print this help'
 	echo '      --version    Print version of this command'
 }
 

--- a/spec/flags.bats
+++ b/spec/flags.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2154
+
+load setup.sh
+
+flags::rejects_unknown() { #@test
+	# Unknown long flag
+	run main --asdf
+	[[ "${status}" -eq 1 ]]
+	[[ "${output}" == 'Unknown option --asdf' ]]
+
+	# Unknown short flag
+	run main -x
+	[[ "${status}" -eq 1 ]]
+	[[ "${output}" == 'Unknown option -x' ]]
+}

--- a/spec/parsing.bats
+++ b/spec/parsing.bats
@@ -5,44 +5,72 @@ load setup.sh
 
 parsing::parses_bash_syntax_variations() { #@test
 	create run.sh '
-run::1() {
-	echo 1
+run::a() {
+	echo a
 }
 
- run::2 (  )
+ run::b (  )
 {
-	echo 2
+	echo b
 }
 
-run::foo=1 # This is not a function/command
+# This is not a function/command
+run::foo=1
 
-function run::3 {
-  run::2
-	echo 3
+function run::c {
+  run::b
+	echo c
 }
 
-	function	run::4			{
-	echo 4
+	function	run::d			{
+	echo d
 }
 '
-	EXPECTED_OUTPUT='1
-2
-3
-4'
+	EXPECTED_OUTPUT='a
+b
+c
+d'
 
 	run main --list
 	[[ "${status}" -eq 0 ]]
 	[[ "${output}" == "${EXPECTED_OUTPUT}" ]]
 
-	run main --info 1
+	run main --info a
 	[[ "${status}" -eq 0 ]]
 
-	run main --info 2
+	run main --info b
 	[[ "${status}" -eq 0 ]]
 
-	run main --info 3
+	run main --info c
 	[[ "${status}" -eq 0 ]]
 
-	run main --info 4
+	run main --info d
 	[[ "${status}" -eq 0 ]]
+}
+
+parsing::disregards_invalid_task_names() { #@test
+	create run.sh '
+run::%foo() {
+	echo
+}
+
+run::1foo() {
+	echo
+}
+
+run::-asdf() {
+	echo
+}
+
+run::--asdf() {
+	echo
+}
+
+run:::asdf() {
+	echo
+}
+'
+	run main --list
+	[[ "${status}" -eq 0 ]]
+	[[ "${output}" == '' ]]
 }

--- a/spec/task.bats
+++ b/spec/task.bats
@@ -28,29 +28,19 @@ run::foo-bar() {
 run::foo_bar() {
 	echo
 }
+
+run::foo:bar() {
+	echo
+}
 '
 
 	EXPECTED_OUTPUT='foo
 foo123
 foo-bar
-foo_bar'
+foo_bar
+foo:bar'
 
 	run main --list
 	[[ "${status}" -eq 0 ]]
 	[[ "${output}" == "${EXPECTED_OUTPUT}" ]]
-}
-
-task::disregards_invalid_task_names() { #@test
-	create run.sh '
-run::foo:bar() {
-	echo
-}
-
-run::%!&@() {
-	echo
-}
-'
-	run main --list
-	[[ "${status}" -eq 0 ]]
-	[[ "${output}" == '' ]]
 }


### PR DESCRIPTION
- Allow `:` to appear in task names
- Require task name to start with letter (`a-zA-Z`)